### PR TITLE
Ensure Immediate File Writing for Translated SRT Output

### DIFF
--- a/tests/test_translate_alloptions_draganddrop.py
+++ b/tests/test_translate_alloptions_draganddrop.py
@@ -64,6 +64,10 @@ print()
 print(f"\033[91mTranslating the file. Model used: ”\033[92m{selected_model}\033[91m”. Please wait...\033[0m")
 print()
 gst.translate()
+if os.path.exists(gst.output_file):
+    with open(gst.output_file, 'a') as f:
+        f.flush()
+        os.fsync(f.fileno())
 
 # Text colored in yellow
 print()


### PR DESCRIPTION
Hi again 😊
This PR adds a small code block to force the flushing and syncing of the output SRT file after translation. The change ensures that the translated file (gst.output_file) is fully written to disk before the program prompts the user to close the console.

The added code checks if the output file exists, flushes the file buffer, and syncs it to disk using os.fsync(). This resolves an issue where the output file appeared empty (0 KB) until the console was closed, improving the user experience by making the translated file immediately available.